### PR TITLE
remove strict pinning

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,10 +35,6 @@ test:
   imports:
     - biofilm
     - biofilm.algo
-  commands:
-    - pip check
-  requires:
-    - pip
 
 about:
   home: https://github.com/smautner/biofilm

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: b285d80da26aebdf41c7b4273c1b31717a035ff731169092a4ca1ac98b2cff3d
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . -vv
   noarch: python
 
@@ -20,16 +20,16 @@ requirements:
     - pip
     - python >=3.8
   run:
-    - auto-sklearn ==0.14.2
-    - dirtyopts ==0.0.18
-    - eden-kernel ==0.3.1348
-    - lmz ==0.1.12
-    - numpy >=1.22.0
     - python >=3.8
+    - auto-sklearn >=0.14.2
+    - dirtyopts >=0.0.18
+    - eden-kernel >=0.3.1348
+    - lmz >=0.1.12
+    - numpy >=1.22.0
     - scikit-learn >=0.24.2
-    - structout ==0.1.44
-    - ubergauss ==0.0.43
-    - pynisher ==0.6.4
+    - structout >=0.1.44
+    - ubergauss >=0.0.43
+    - pynisher >=0.6.4
 
 test:
   imports:


### PR DESCRIPTION
Is the strict pinning really needed? This makes it very hard to build dependent packages.